### PR TITLE
Adapt to new InducingPoints.jl API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AugmentedGaussianProcesses"
 uuid = "38eea1fd-7d7d-5162-9d08-f89d0f2e271e"
 authors = ["Theo Galy-Fajou <theo.galyfajou@gmail.com>"]
-version = "0.11.3"
+version = "0.11.4"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/ComplementaryDistributions/generalizedinversegaussian.jl
+++ b/src/ComplementaryDistributions/generalizedinversegaussian.jl
@@ -5,7 +5,7 @@ struct GeneralizedInverseGaussian{T<:Real} <: Distributions.ContinuousUnivariate
     b::T
     p::T
     function GeneralizedInverseGaussian{T}(a::T, b::T, p::T) where {T}
-        Distributions.@check_args(GeneralizedInverseGaussian, a > zero(a) && b > zero(b))
+        a > zero(a) && b > zero(b) || throw(ArgumentError("a : $a and b : $b have to be positive"))
         return new{T}(a, b, p)
     end
 end

--- a/src/training/onlinetraining.jl
+++ b/src/training/onlinetraining.jl
@@ -187,7 +187,7 @@ function init_online_model(m::OnlineSVGP{T}, x) where {T<:Real}
 end
 
 function init_online_gp!(gp::OnlineVarLatent{T}, x, jitt::T=T(jitt)) where {T}
-    Z = InducingPoints.initZ(gp.Zalg, x; kernel=kernel(gp))
+    Z = InducingPoints.inducingpoints(gp.Zalg, x; kernel=kernel(gp))
     k = length(Z)
     post = OnlineVarPosterior{T}(k)
     prior = GPPrior(kernel(gp), pr_mean(gp))

--- a/test/likelihood/gaussian.jl
+++ b/test/likelihood/gaussian.jl
@@ -27,7 +27,7 @@
             @test AGP.getf(model) isa AGP.LatentGP
             @test AGP.n_latent(model) == 1
             L = AGP.objective(model, X, y)
-            @test_nowarn train!(model, 10)
+            train!(model, 10)
             @test L < AGP.objective(model, X, y)
             @test testconv(model, "Regression", X, f, y)
             @test all(proba_y(model, X)[2] .> 0)


### PR DESCRIPTION
This uses `inducingpoints(alg, x kwargs...)` instead of `initZ(alg, x; kwargs...)`